### PR TITLE
Fix conflicting Treaty Port event triggers

### DIFF
--- a/HFM/events/China.txt
+++ b/HFM/events/China.txt
@@ -662,7 +662,8 @@ country_event = {
 
 	option = {
 		name = "EVT90909OPTA"
-		1481 = { secede_province = FROM add_province_modifier = { name = chinese_treaty_port duration = -1 } }
+		1481 = { secede_province = FROM }
+		FROM = { add_country_modifier = { name = chinese_treaty_port duration = 1095 } }		
 		any_pop = { limit = { is_culture_group = east_asian } militancy = 1 }
 		prestige_factor = -0.1
 		ai_chance = { factor = 0.8 }

--- a/HFM/events/CivilizationAndGunBoats.txt
+++ b/HFM/events/CivilizationAndGunBoats.txt
@@ -4715,9 +4715,19 @@ province_event = {
 				NOT = { province_id = 1496 }
 				NOT = { province_id = 1569 }
 				NOT = { province_id = 1566 }
+				NOT = { province_id = 2632 }
+				NOT = { province_id = 1538 }
 			}
 			AND = { province_id = 1569 total_pops = 30000 }
 			AND = { province_id = 1566 total_pops = 30000 }
+			AND = {
+				province_id = 2632
+				OR = {
+					total_pops = 30000
+					1496 = { trade_goods = precious_goods }
+				}
+			}
+			AND = { province_id = 1538 total_pops = 90000 }
 		}
 		port = yes
 		NOT = { has_province_modifier = treaty_port }


### PR DESCRIPTION
Negotiating an unequal treaty for a valuable Chinese treaty port is a sound imperialistic strategy, but some of the choices for treaty ports are more valuable than others, due to the extremely lucrative Precious Goods RGO.

Most of the ports are fixed with regards to the potential for Precious Goods, but a few provinces such as Shanghai have their event trigger scripted such that they will only switch RGOs if their population is below a certain threshold. This is all well and good, but the problem is there are _two_ possible Treaty Port events: one that activates Precious Goods and one that does not. The problem is that some ports like _Shanghai could have the wrong event fire due to overlapping trigger conditions._

The first event, **id = 90954** : https://github.com/SighPie/HFM/blob/Development/HFM/events/CivilizationAndGunBoats.txt#L4541-L4590

This event is restricted to only certain provinces, and provides them with the Precious Goods RGO. Notice provinces **1569, 1566, 2632, and 1538** have population thresholds, among other triggering conditions. This event has a MTTH of 8 months.

The second event, **id = 90958** : https://github.com/SighPie/HFM/blob/Development/HFM/events/CivilizationAndGunBoats.txt#L4704-L4739

This version of a treaty port does not provide the Precious Goods RGO, and also has a MTTH of 8 months. It will trigger for any port other than the ones explicitly enumerated, such as if provinces **1566 or 1569** exceed the population threshold. There is a big problem, though: Shanghai (**province_id = 1538**) is not explicitly enumerated here, but it is in the first event. This means that if one initially obtains the Shanghai treaty port underneath the population limit, _both of these event trigger conditions are satisfied_, and since they both have MTTH of 8 months, they are both equally likely to trigger. This means you can potentially be denied your Precious Goods, despite satisfying the conditions. While the same could happen, in theory, for province 2632 (Kwangchowan), this is highly unlikely because in order for it to switch to Precious Goods, Hong Kong must _not_ have already switched, but Hong Kong will nearly _always_ have switched after the first Opium War.

In any event, I have added additional trigger conditions to hopefully fix this issue.