### PR TITLE
Fix bug giving Britain unlimited call_allies cbs

### DIFF
--- a/HFM/decisions/FlavourMod_Setup_CleanUp.txt
+++ b/HFM/decisions/FlavourMod_Setup_CleanUp.txt
@@ -204,9 +204,12 @@ political_decisions = {
 					war = yes
 					EIC = { exists = yes war = no }
 				}
-				MUG = {
-					war_with = ENG
-					NOT = { war_with = EIC }
+				AND = {
+					war_with = MUG
+					EIC = {
+						exists = yes
+						NOT = { war_with = MUG }
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Under certain conditions, the `cleanup_eic` decision will be given to Britain for an entire duration of a war with against `MUG`, which can cause the game to slow down a bit (from my experience with 
[700+ British Wars of Aggression](https://user-images.githubusercontent.com/3220800/41060313-dd0a24c0-6994-11e8-8f6f-bc77c67622c0.PNG)).

Conditions to reproduce:
1. `EIC` must not exist
2. `RAJ` must exist
3. `RAJ` must be a vassal or substate of `ENG`
4. `ENG` must be at with with `MUG`
