### PR TITLE
Fix incorrect govt_flag block for Korea.

### DIFF
--- a/HFM/history/countries/KOR - Korea.txt
+++ b/HFM/history/countries/KOR - Korea.txt
@@ -51,9 +51,6 @@ upper_house = {
 govt_flag = {
 	government = hms_government
 	flag = democracy
-	
-	government = prussian_constitutionalism
-	flag = democracy
 }
 
 foreign_weapons = yes_foreign_weapons


### PR DESCRIPTION
Since a `govt_flag` block can be used for just one exception rule,
constitutional monarchy gets to be the one to use the republican flag.
This leaves semi-constitutional monarchy to use the Joseon flag by
default.