### PR TITLE
Restrict 'Restore Democracy in South America'

### DIFF
--- a/HFM/decisions/FlavourMod_GreatPowers.txt
+++ b/HFM/decisions/FlavourMod_GreatPowers.txt
@@ -56,41 +56,37 @@ political_decisions = {
 	restore_republic_south_america = {
 		picture = "switch_to_liberty"
 		potential = {
+			capital_scope = { continent = south_america }
+			is_greater_power = no
+			civilized = yes
 			OR = {
-				AND = {
-					capital_scope = { continent = south_america }	
-					is_greater_power = no
-					civilized = yes
-					OR = {
-						government = hms_government
-						government = democracy
-					}
-				}
+				government = hms_government
+				government = democracy
 			}
 			war = no
-			is_substate = no
 			is_vassal = no
 		}
 		
 		allow = {
-			any_neighbor_country = { 
-				government = proletarian_dictatorship 	
-				is_vassal = no
-				NOT = { truce_with = THIS }
-			}
 			OR = {
 				government = hms_government
 				government = democracy
+			}
+			any_neighbor_country = {
+				government = proletarian_dictatorship
+				capital_scope = { continent = south_america }
+				is_vassal = no
+				NOT = { truce_with = THIS }
 			}
 		}
 		
 		effect = {
 			any_neighbor_country = {
 				limit = {
-					capital_scope = { continent = south_america }
-					exists = yes
 					government = proletarian_dictatorship
-					war = no
+					capital_scope = { continent = south_america }
+					is_vassal = no
+					NOT = { truce_with = THIS }
 				}
 				country_event = 99956
 			}


### PR DESCRIPTION
The conditions & effects of the decision were not agreeing with one
another, which could lead to the following bugs:

- an ineffective decision when a communist country outside South America
  had some land there (e.g. communist France holding French Guyana)
- an ineffective decision against countries at war
- the country declaring war against countries which are vassals
- the country declaring war on countries with which it has a truce

Other improvement:

- changed order of `allow` triggers for tooltip purposes

Co-authored-by: moretrim <49937701+moretrim@users.noreply.github.com>