### PR TITLE
Leave Ryukyu independent during Meiji Restoration

### DIFF
--- a/HFM/decisions/Japan.txt
+++ b/HFM/decisions/Japan.txt
@@ -535,7 +535,6 @@ political_decisions = {
 			government = prussian_constitutionalism
 			any_pop = { militancy = -2 }
 			
-			create_vassal = RYU
 		}
 		
 		ai_will_do = { factor = 1 }

--- a/HFM/events/JAPFlavor.txt
+++ b/HFM/events/JAPFlavor.txt
@@ -1411,7 +1411,6 @@ country_event = {
 			}
 			inherit = THIS
 		}
-		create_vassal = RYU
 	}
 }
 
@@ -1749,7 +1748,6 @@ country_event = {
 			end_war = THIS
 			country_event = 97652
 		}
-		create_vassal = RYU
 	}
 }
 


### PR DESCRIPTION
When a Daimyo won the Boshin War on behalf of the emperor, their country
would become Imperial Japan and Ryukyu would end up being made the
vassal of a now defunct country.

This could be fixed by tweaking the `change_tag` and `create_vassal =
RYU` interaction. Instead this changes Ryukyu to be left independent
because I could not find a reason to enforce this. Most especially,
Ryukyu was under dual influence by Japan and China until 1874, further
resisting removal of sovereignty until 1879.

Likewise Ryukyu is left independent during the Tokugawa Victory event,
and the Meiji Constitution decision.

For historical accuracy, it seemed best to rely upon the Ryukyu
annexation decision instead of enforcing puppetry here: The
`inherit_ryukyu` decision is a more elegant way of expressing the
situation. This also forces Japan to earn their conquest of Ryukyu
through usually sphering it, instead of automatically acquiring it.

I have left in the stipulation in `inherit_ryukyu` that prevents the ai
from clicking it when when the player is Ryukyu.

Pictorially, here is the original problem, with Ryukyu as a satellite of
a non-existant Choshu:
 ![RyukyuPuppetry](https://user-images.githubusercontent.com/17787203/69486746-befa8000-0e03-11ea-863f-84520a735929.png)

 With the changes, this no longer happens, but ai Japan annexes Ryukyu
 quickly at any rate, after readily sphering them:
 ![RyukyuPuppetry](https://user-images.githubusercontent.com/17787203/69489570-ea469480-0e2e-11ea-8bdb-91526397b760.png)

 After sphering:
![RyukyuPuppetry](https://user-images.githubusercontent.com/17787203/69489602-b324b300-0e2f-11ea-905c-10290038e549.png)