### PR TITLE
Convert outstanding files to cp1252

### DIFF
--- a/HFM/common/countries/Louisiana.txt
+++ b/HFM/common/countries/Louisiana.txt
@@ -139,29 +139,29 @@ party = {
 
 unit_names = {
 	dreadnought = {
-		QuÃ©bec MontrÃ©al Acadie Canada Cartier Montcalm "De la Salle" DÃ©troit Vaudreuil Frontenac Chevalier "Saint-Laurent" 
-		"Trois-RiviÃ¨res" Champlain Richelieu 
+		Québec Montréal Acadie Canada Cartier Montcalm "De la Salle" Détroit Vaudreuil Frontenac Chevalier "Saint-Laurent" 
+		"Trois-Rivières" Champlain Richelieu 
 		
 	}
 	ironclad = {
-		QuÃ©bec MontrÃ©al Acadie Canada Cartier Montcalm "De la Salle" DÃ©troit Vaudreuil Frontenac Chevalier "Saint-Laurent" 
-		"Trois-RiviÃ¨res" Champlain Richelieu
+		Québec Montréal Acadie Canada Cartier Montcalm "De la Salle" Détroit Vaudreuil Frontenac Chevalier "Saint-Laurent" 
+		"Trois-Rivières" Champlain Richelieu
 	}
 	manowar = {
-		QuÃ©bec MontrÃ©al Acadie Canada Cartier Montcalm "De la Salle" DÃ©troit Vaudreuil Frontenac Chevalier "Saint-Laurent" 
-		"Trois-RiviÃ¨res" Champlain Richelieu 
+		Québec Montréal Acadie Canada Cartier Montcalm "De la Salle" Détroit Vaudreuil Frontenac Chevalier "Saint-Laurent" 
+		"Trois-Rivières" Champlain Richelieu 
 	}
 	cruiser = {
-		QuÃ©bec MontrÃ©al Acadie Canada Cartier Montcalm "De la Salle" DÃ©troit Vaudreuil Frontenac Chevalier "Saint-Laurent" 
-		"Trois-RiviÃ¨res" Champlain Richelieu 
+		Québec Montréal Acadie Canada Cartier Montcalm "De la Salle" Détroit Vaudreuil Frontenac Chevalier "Saint-Laurent" 
+		"Trois-Rivières" Champlain Richelieu 
 	}
 	frigate = {
-		QuÃ©bec MontrÃ©al Acadie Canada Cartier Montcalm "De la Salle" DÃ©troit Vaudreuil Frontenac Chevalier "Saint-Laurent" 
-		"Trois-RiviÃ¨res" Champlain Richelieu 
+		Québec Montréal Acadie Canada Cartier Montcalm "De la Salle" Détroit Vaudreuil Frontenac Chevalier "Saint-Laurent" 
+		"Trois-Rivières" Champlain Richelieu 
 	}
 	monitor = {
-		QuÃ©bec MontrÃ©al Acadie Canada Cartier Montcalm "De la Salle" DÃ©troit Vaudreuil Frontenac Chevalier "Saint-Laurent" 
-		"Trois-RiviÃ¨res" Champlain Richelieu 
+		Québec Montréal Acadie Canada Cartier Montcalm "De la Salle" Détroit Vaudreuil Frontenac Chevalier "Saint-Laurent" 
+		"Trois-Rivières" Champlain Richelieu 
 	}
 	clipper_transport = {
 		
@@ -170,7 +170,7 @@ unit_names = {
 		
 	}
 	commerce_raider = {
-		QuÃ©bec MontrÃ©al Acadie Canada Cartier Montcalm "De la Salle" DÃ©troit Vaudreuil Frontenac Chevalier "Saint-Laurent" 
-		"Trois-RiviÃ¨res" Champlain Richelieu 
+		Québec Montréal Acadie Canada Cartier Montcalm "De la Salle" Détroit Vaudreuil Frontenac Chevalier "Saint-Laurent" 
+		"Trois-Rivières" Champlain Richelieu 
 	}
 }

--- a/HFM/common/countries/Nationalist France.txt
+++ b/HFM/common/countries/Nationalist France.txt
@@ -2,7 +2,7 @@ color = { 181  181  229 }
 graphical_culture = EuropeanGC
 
 party = {
-	name = "FRA_reactionary" #LÃ©gitimiste
+	name = "FRA_reactionary" #Légitimiste
 	start_date = 1830.1.1
 	end_date = 1883.1.1
 
@@ -32,7 +32,7 @@ party = {
 }
 
 party = {
-	name = "FRA_liberal" #RÃ©publicain
+	name = "FRA_liberal" #Républicain
 	start_date = 1830.1.1
 	end_date = 1848.1.1
 
@@ -47,7 +47,7 @@ party = {
 }
 
 party = {
-	name = "FRA_liberal_2" #Union libÃ©rale
+	name = "FRA_liberal_2" #Union libérale
 	start_date = 1848.1.1
 	end_date = 1870.1.1
 	
@@ -62,7 +62,7 @@ party = {
 }
 
 party = {
-	name = "FRA_liberal_3" #RÃ©publicain LibÃ©ral
+	name = "FRA_liberal_3" #Républicain Libéral
 	start_date = 1870.1.1
 	end_date = 2000.1.1
 
@@ -77,7 +77,7 @@ party = {
 }
 
 party = {
-	name = "FRA_conservative" #OrlÃ©aniste
+	name = "FRA_conservative" #Orléaniste
 	start_date = 1830.1.1
 	end_date = 1848.1.1
 
@@ -107,7 +107,7 @@ party = {
 }
 
 party = {
-	name = "FRA_conservative_3" #RÃ©publicain modÃ©rÃ©
+	name = "FRA_conservative_3" #Républicain modéré
 	start_date = 1860.1.1
 	end_date = 2000.1.1
 
@@ -122,7 +122,7 @@ party = {
 }
 
 party = {
-	name = "FRA_conservative_4" #OrlÃ©aniste
+	name = "FRA_conservative_4" #Orléaniste
 	start_date = 1870.1.1
 	end_date = 1894.1.1
 
@@ -152,7 +152,7 @@ party = {
 }
 
 party = {
-	name = "FRA_socialist" #RÃ©publicain dÃ©mocratique
+	name = "FRA_socialist" #Républicain démocratique
 	start_date = 1870.1.1
 	end_date = 2000.1.1
 
@@ -197,7 +197,7 @@ party = {
 }
 
 party = {
-	name = "FRA_anarcho_liberal" #RÃ©publicain radical
+	name = "FRA_anarcho_liberal" #Républicain radical
 	start_date = 1830.1.1
 	end_date = 2000.1.1
 
@@ -212,7 +212,7 @@ party = {
 }
 
 party = {
-	name = "FRA_communist" #Parti Ouvrier FranÃ§ais
+	name = "FRA_communist" #Parti Ouvrier Français
 	start_date = 1848.1.1
 	end_date = 2000.1.1
 
@@ -243,12 +243,12 @@ party = {
 
 unit_names = {
 	dreadnought = {
-		"Dunkerque" "Strasbourg" "Richelieu" "Clemenceau" "Petain" "NapolÃ©on" "Poincare"
-		"Louis XIV" "Alsace" "Bourgogne" "Poitou" "Calais" "Rouen" "Brest" "DÃ©vastation"
-		"Courbet" "Amiral DuperrÃ©" "Terrible" "Indomptable" "Caiman" "Requin" "Admiral Baudin"
+		"Dunkerque" "Strasbourg" "Richelieu" "Clemenceau" "Petain" "Napoléon" "Poincare"
+		"Louis XIV" "Alsace" "Bourgogne" "Poitou" "Calais" "Rouen" "Brest" "Dévastation"
+		"Courbet" "Amiral Duperré" "Terrible" "Indomptable" "Caiman" "Requin" "Admiral Baudin"
 		"Formidable" "Hoche" "Marceau" "Magenta" "Neptune" "Brennus" "Charles Martel" "Carnot"
-		"JaurÃ©guiberry" "MassÃ©na" "Bouvet" "Charlemagne" "Saint Louis" "Gaulois" "Henri IV"
-		"IÃ©na" "Suffren" "RÃ©publique" "Patrie" "DÃ©mocratie" "Justice" "LibertÃ©" "VeritÃ©"
+		"Jauréguiberry" "Masséna" "Bouvet" "Charlemagne" "Saint Louis" "Gaulois" "Henri IV"
+		"Iéna" "Suffren" "République" "Patrie" "Démocratie" "Justice" "Liberté" "Verité"
 		"Danton" "Diderot" "Mirabeau" "Vergniaud" "Voltaire" "Condorcet" "Courbet" "France"
 		"Jean Bart" "Paris" "Fleurus" "Bretagne" "Lorraine" "Provence" "Bearn" "Flandre"
 		"Gascoigne" "Languedoc" "Normandie" "Guyenne" "Champagne" "Auvergne" "Lille" "Lyon"
@@ -256,57 +256,57 @@ unit_names = {
 	}
 	
 	battleship = {
-		"Brennus" "Charles Martel" "Carnot" "JaurÃ©guiberry" "MassÃ©na" Bouvet Charlemagne "St Louis" Gaulois IÃ©na Suffren RÃ©publique Patrie LibertÃ© Justice VÃ©ritÃ© DÃ©mocratie Danton Voltaire Diderot Condorcet Mirebeau Vergniaud "Henri IV"
+		"Brennus" "Charles Martel" "Carnot" "Jauréguiberry" "Masséna" Bouvet Charlemagne "St Louis" Gaulois Iéna Suffren République Patrie Liberté Justice Vérité Démocratie Danton Voltaire Diderot Condorcet Mirebeau Vergniaud "Henri IV"
 	}
 	
 	ironclad = {
 		"Congreve" "Foudroyante" "Lave" "Tonnante" "Gloire" "Invincible" "Normandie" "Couronne"
 		"Magenta" "Solferino" "Flandre" "Gauloise" "Magnanime" "Provence" "Revanche" "Savoie"
-		"Surveillante" "Valeureuse" "HÃ©roÃ¯ne"
+		"Surveillante" "Valeureuse" "Héroïne"
 	}
 	manowar = {
-		"Alexandre" "Breslaw" "Prince JÃ©rÃ´me" "Ville de Paris" "Ville de Nantes" "Duguay-Trouin"
+		"Alexandre" "Breslaw" "Prince Jérôme" "Ville de Paris" "Ville de Nantes" "Duguay-Trouin"
 		"Tage" "Donawerth" "Saint Louis" "Fontenoy" "Turenne" "Ville de Bordeaux" "Castiglione"
-		"MassÃ©na" "Bayard" "Ville de Lyon" "Louis XIV"
+		"Masséna" "Bayard" "Ville de Lyon" "Louis XIV"
 	}
 	cruiser = {
 		"Clovis" "Maurice de Saxe" "Vercingetorix" "Richemont" "Dunois" "Ney" "Leger" "Vauban"
 		"Conde" "Turenne" "Montebello" "Austerlitz" "Souverain" "Navarin" "Ulm" "Wagram"
-		"AlgÃ©siras" "Arcole" "Friedland" "ImpÃ©rial" "Eylau" "Tilsitt" "Jena" "Auerstadt"
-		"Marengo" "Toulon" "Bellone" "Glorieuse" "Gracieuse" "Audacieuse" "ImpÃ©tueuse" "Ardente"
-		"Victoire" "GuerriÃ¨re" "TÃ©mÃ©raire" "Triomphant" "Tigre" "PersÃ©vÃ©rante" "Vigilant"
-		"Tenace" "Ã‰lan" "Duguay Trouin" "Lamotte-Picquet" "Primaguet" "Duquesne" "Tourville"
-		"Colbert" "Foch" "AlgÃ©rie" "Jeanne D'Arc" "Maroc" "Lafayette" "Davout" "Suchet" "Forbin"
-		"Surcouf" "Cosmao" "Lalande" "GalilÃ©e" "Lavoisier" "Linois" "La Galissionere"
+		"Algésiras" "Arcole" "Friedland" "Impérial" "Eylau" "Tilsitt" "Jena" "Auerstadt"
+		"Marengo" "Toulon" "Bellone" "Glorieuse" "Gracieuse" "Audacieuse" "Impétueuse" "Ardente"
+		"Victoire" "Guerrière" "Téméraire" "Triomphant" "Tigre" "Persévérante" "Vigilant"
+		"Tenace" "Élan" "Duguay Trouin" "Lamotte-Picquet" "Primaguet" "Duquesne" "Tourville"
+		"Colbert" "Foch" "Algérie" "Jeanne D'Arc" "Maroc" "Lafayette" "Davout" "Suchet" "Forbin"
+		"Surcouf" "Cosmao" "Lalande" "Galilée" "Lavoisier" "Linois" "La Galissionere"
 		"Jean de Vienne" "Gloire" "Marseillaise" "Georges Leygues" "De Grasse" "La Fantasque"
 		"Iphigenie" "Naiade" "Arethuse" "Dubourdieu" "Milan" "Belliqueuse" "Sfax" "Tage"
-		"Amiral CÃ©cille" "Davout" "Suchet" "CoÃ«tlogon" "Forbin" "Surcouf" "Cosmao" "Lalande"
-		"Troude" "GalilÃ©e" "Lavoisier" "Linois" "TunisiÃ©" "Isly" "Bugeaud" "Chasseloup-Laubat"
+		"Amiral Cécille" "Davout" "Suchet" "Coëtlogon" "Forbin" "Surcouf" "Cosmao" "Lalande"
+		"Troude" "Galilée" "Lavoisier" "Linois" "Tunisié" "Isly" "Bugeaud" "Chasseloup-Laubat"
 		"Friant" "Descartes" "Pascal" "Cassard" "D'Assas" "Du Chayla" "Catinat" "Protet"
-		"D'Entrecasteaux" "Guichen" "ChÃ¢teaurenault" "D'EstrÃ©es" "Infernet" "Jurien de la GraviÃ¨re"
+		"D'Entrecasteaux" "Guichen" "Châteaurenault" "D'Estrées" "Infernet" "Jurien de la Gravière"
 		"Pluton" "Emile Bertin" "Dupuy de Lome" "Admiral Charner" "Bruix" "Chanzy" "Latouche-Treville"
 		"Pothau" "Dupetit-Thouars" "Gueydon" "Montcalm" "Desaix" "Dupleix" "Kleber"
 		"Amiral Aube" "Conde" "Sully" "Leon Gambetta" "Victor Hugo" "Jules Michelet"
 		"Ernest Renan" "Edgar Quinet" "Waldeck-Rousseau" "Thionville" "Metz" "Mulhouse" "Colmar"
-		"D'Assas" "Du Chayla" "Catinat" "Protet" "D'Entrecasteaux" "Guichen" "ChÃ¢teaurenault"
+		"D'Assas" "Du Chayla" "Catinat" "Protet" "D'Entrecasteaux" "Guichen" "Châteaurenault"
 	}
 	frigate = {
 		"Condor" "Epervier" "Faucon" "Vautour" "Wattignies" "Levrier" "Casablanca" "D'Iberville"
-		"Cassini" "Lahire" "CircÃ©" "Hermione" "Pallas" "SÃ©miramis" "Armorique" "Junon"
-		"Magicienne" "ThÃ©mis" "Flore"
+		"Cassini" "Lahire" "Circé" "Hermione" "Pallas" "Sémiramis" "Armorique" "Junon"
+		"Magicienne" "Thémis" "Flore"
 	}
 	monitor = {
-		"OcÃ©an" "Marengo" "Suffren" "Friedland" "Richelieu" "Colbert" "Trident"
+		"Océan" "Marengo" "Suffren" "Friedland" "Richelieu" "Colbert" "Trident"
 	}
 	clipper_transport = {
 	}
 	steam_transport = {
 	}
 	commerce_raider = {
-		"AsmodÃ©e" "Gomer" "Darien" "Labrador" "Ulloa" "Cacique" "Canada" "Christophe Colomb"
-		"Eldorado" "Magellan" "Montezuma" "OrÃ©noque" "Panama" "Albatros" "Descartes" "Vauban"
-		"Caffarelli" "Mogador" "Pomone" "Isly" "Bellone" "Foudre" "ImpÃ©ratrice EugÃ©nie"
-		"Souveraine" "Audacieuse" "ImpÃ©tueuse" "Ardente" "Victoire" "GuerriÃ¨re" "RenommÃ©e"
-		"DanaÃ©" "Pandore" "ZÃ©nobie" "Clorinde" "AstrÃ©e"
+		"Asmodée" "Gomer" "Darien" "Labrador" "Ulloa" "Cacique" "Canada" "Christophe Colomb"
+		"Eldorado" "Magellan" "Montezuma" "Orénoque" "Panama" "Albatros" "Descartes" "Vauban"
+		"Caffarelli" "Mogador" "Pomone" "Isly" "Bellone" "Foudre" "Impératrice Eugénie"
+		"Souveraine" "Audacieuse" "Impétueuse" "Ardente" "Victoire" "Guerrière" "Renommée"
+		"Danaé" "Pandore" "Zénobie" "Clorinde" "Astrée"
 	}
 }

--- a/HFM/decisions/FlavourMod_Africa.txt
+++ b/HFM/decisions/FlavourMod_Africa.txt
@@ -1707,9 +1707,9 @@ political_decisions = {
 			prestige = 2
 			treasury = -50000
 			set_country_flag = founding_german_namibia 
-			2084 = { secede_province = THIS change_province_name = "LÃ¼deritzbucht" any_pop = { literacy = -0.99 } life_rating = 21 }
+			2084 = { secede_province = THIS change_province_name = "Lüderitzbucht" any_pop = { literacy = -0.99 } life_rating = 21 }
 			2086 = { secede_province = THIS change_province_name = "Keetmanshoop" any_pop = { literacy = -0.99 } life_rating = 25 }
-			2085 = { secede_province = THIS change_province_name = "MaltahÃ¶he" any_pop = { literacy = -0.99 } life_rating = 25 }
+			2085 = { secede_province = THIS change_province_name = "Maltahöhe" any_pop = { literacy = -0.99 } life_rating = 25 }
 			2078 = { secede_province = THIS any_pop = { literacy = -0.99 } }
 			2079 = { secede_province = THIS any_pop = { literacy = -0.99 } }
 			2080 = { secede_province = THIS any_pop = { literacy = -0.99 } }
@@ -1772,7 +1772,7 @@ political_decisions = {
 			#random_owned = {
 			#	limit = { owner = { is_culture_group = germanic } } 
 			#	owner = {
-			#		1915 = { change_province_name = "MisahÃ¶he" }
+			#		1915 = { change_province_name = "Misahöhe" }
 			#	}
 			#}
 		}

--- a/HFM/decisions/FlavourMod_GER.txt
+++ b/HFM/decisions/FlavourMod_GER.txt
@@ -954,7 +954,7 @@ political_decisions = {
 			690 = { naval_base = 3 }
 			random_owned = {
 				limit = {
-					province_id = 690 #Westpreu√üen
+					province_id = 690 #Westpreuﬂen
 					state_scope = {
 						NOT = { has_building = steamer_shipyard }
 					}
@@ -1059,7 +1059,7 @@ political_decisions = {
 					OR = {
 						region = PRU_682 #Lower Silesia
 						region = PRU_701 #Posen
-						region = PRU_690 #Westpreu√üen
+						region = PRU_690 #Westpreuﬂen
 						
 					}
 				}

--- a/HFM/decisions/FlavourMod_RUS.txt
+++ b/HFM/decisions/FlavourMod_RUS.txt
@@ -120,7 +120,7 @@ political_decisions = {
 		ai_will_do = { factor = 1 }
 	}
 	
-	build_the_st_petersburg_moscow_railway = { #Saint Petersburgâ€“Moscow Railway
+	build_the_st_petersburg_moscow_railway = { #Saint Petersburg–Moscow Railway
 		picture = whistlestop_tour
 		potential = {
 			tag = RUS

--- a/HFM/events/MISC_Flavour.txt
+++ b/HFM/events/MISC_Flavour.txt
@@ -31,7 +31,7 @@ country_event = {
 	}
 }
 
-# The SÃ¼dtirol Compromise
+# The Südtirol Compromise
 country_event = {
 	id = 110089
 	title = "EVTNAME110089"

--- a/HFM/events/SAF.txt
+++ b/HFM/events/SAF.txt
@@ -731,7 +731,7 @@ country_event = {
 		name = "EVT6012OPTB"
 		set_country_flag = rename_mashonaland_boer
 		2068 = { change_province_name = "Herculaastad" }
-		2068 = { state_scope = { change_region_name = RhodesiÃ« } }
+		2068 = { state_scope = { change_region_name = Rhodesië } }
 	}
 	
 	option = {
@@ -1854,7 +1854,7 @@ country_event = { #Petition Portugal for port access
 				owned_by = THIS 
 			}
 		}
-		2049 = { #Portugal owns LourenÃ§o Marques
+		2049 = { #Portugal owns Lourenço Marques
 			owned_by = POR
 		}
 		relation = { #Needs positive relations with Portugal

--- a/HFM/inventions/PDM_famous_people_culture.txt
+++ b/HFM/inventions/PDM_famous_people_culture.txt
@@ -300,7 +300,7 @@ thomas_brown  = {
 	}	
 }
 
-#SÃ¸ren Kierkegaard
+#Søren Kierkegaard
 soren_kierkegaard  = {
 	limit = {
 		associationism = 1

--- a/HFM/localisation/0000_minimod.csv
+++ b/HFM/localisation/0000_minimod.csv
@@ -14,5 +14,5 @@ jerriais;Jerriais;;;;;;;;;;;;;x
 anglo_canadian;Anglo-Canadian;Anglo-canadien;Anglokanadisch;;Anglocanadiense;;;;;;;;;x;;;;
 french_canadian;French-Canadien;Franco-canadien;Frankokanadisch;;Franco-canadiense;;;;;;;;;x;;;;
 anglo_indian;Anglo-Indian;;;;;;;;;;;;;x
-british;English;Britannique;Britisch;;Britå«•ica;;;;;;;;;x;;;;
+british;English;Britannique;Britisch;;Británica;;;;;;;;;x;;;;
 pan_french_nationalism;Pan-French Nationalism;;;;;;;;;x;;;;

--- a/HFM/localisation/00_msc_localization.csv
+++ b/HFM/localisation/00_msc_localization.csv
@@ -4,7 +4,7 @@ organize_central_asia_desc;Our domination over the steppes is now uncontested: i
 conquest_of_red_water_title;Conquest of the coast;;;;;;;;;;;;;;;;;;;;;;;;;x
 conquest_of_red_water_desc;Our control over the Turkmenia region is now complete enough that we can make our move towards the Caspian Sea by conquering the area known as Kyzyl-Su, the Red Water, before anyone else cut us there.;;;;;;;;;;;;;;;;;;;;;;;;;x
 claim_artois_title;Claim Artois;;;;;;;;;;;;;;;;;;;;;;;;;x
-claim_artois_desc;The comtÃ© d'Artois has traditionally been part of the Low Countries. Only during the era of foreign rule by Habsburg scum was it snatched by the King of France. As such, it is our duty to reclaim those lands back into our glorious realm, put their people to work and profit from their land!;;;;;;;;;;;;;;;;;;;;;;;;;x
+claim_artois_desc;The comté d'Artois has traditionally been part of the Low Countries. Only during the era of foreign rule by Habsburg scum was it snatched by the King of France. As such, it is our duty to reclaim those lands back into our glorious realm, put their people to work and profit from their land!;;;;;;;;;;;;;;;;;;;;;;;;;x
 rename_artois_NET_title;Artois is ours!;;;;;;;;;;;;;;;;;;;;;;;;;x
 rename_artois_NET_desc;The region of Artois is finally back in $COUNTRY_ADJ$ hands! The area has been part of our rightful historical realm and this should reflect on the world's maps.;;;;;;;;;;;;;;;;;;;;;;;;;x
 rename_artois_FRA_title;Artois is ours!;;;;;;;;;;;;;;;;;;;;;;;;;x
@@ -40,8 +40,8 @@ EVTDESC110088;Father Roberto Landel de Moura was ordained to the priesthood in 1
 EVT110088OPTA;Support his effort!;;;;;;;;;;;;;x,,,,,,,,,,,,,,,,,,,,,,
 EVT110088OPTB;Give him an official acknowledgment.;;;;;;;;;;;;;x,,,,,,,,,,,,,,,,,,,,,,
 EVT110088OPTC;Interesting I'm sure...;;;;;;;;;;;;;x,,,,,,,,,,,,,,,,,,,,,,
-EVTNAME110089;The SÃ¼dtirol Compromise.;;;;;;;;;;;;;x,,,,,,,,,,,,,,,,,,,,,,
-EVTDESC110089;Ever since we established our control of the SÃ¼dtirol area there has been discontent. Nationalist troubles agitate the region and riots are more and more common. In a spirit of appeasement, some advisors think it could be wise to cede part of the land... for a price. We'd agree to relish our claims on their share as they would for ours. A German north and an Italian south. Let's hope this resolves tensions amongst our nations.;;;;;;;;;;;;;x,,,,,,,,,,,,,,,,,,,,,,
+EVTNAME110089;The Südtirol Compromise.;;;;;;;;;;;;;x,,,,,,,,,,,,,,,,,,,,,,
+EVTDESC110089;Ever since we established our control of the Südtirol area there has been discontent. Nationalist troubles agitate the region and riots are more and more common. In a spirit of appeasement, some advisors think it could be wise to cede part of the land... for a price. We'd agree to relish our claims on their share as they would for ours. A German north and an Italian south. Let's hope this resolves tensions amongst our nations.;;;;;;;;;;;;;x,,,,,,,,,,,,,,,,,,,,,,
 EVT110089OPTA;The land is rightfully theirs.;;;;;;;;;;;;;x,,,,,,,,,,,,,,,,,,,,,,
 EVT110089OPTB;The land is rightfully ours.;;;;;;;;;;;;;x,,,,,,,,,,,,,,,,,,,,,,
 EVTNAME110090;The Trentino Compromise.;;;;;;;;;;;;;x,,,,,,,,,,,,,,,,,,,,,,

--- a/HFM/localisation/EIC.csv
+++ b/HFM/localisation/EIC.csv
@@ -51,7 +51,7 @@ EIC_independent_conservative;Imperial Conservative Party;;;;;;;;;;;;x
 EIC_independent_liberal;Responsible Rule Party;;;;;;;;;;;;x
 EIC_independent_anarcho_liberal;National Alliance Party;;;;;;;;;;;;x
 EIC_independent_reactionary;Imperial Governance League;;;;;;;;;;;;x
-EIC_independent_socialist;Indian National Congress;CongrÃ¨s national indien;Indischer Nationalkongress;;Congreso Nacional Indio;;;;;;;;;x;;
+EIC_independent_socialist;Indian National Congress;Congrès national indien;Indischer Nationalkongress;;Congreso Nacional Indio;;;;;;;;;x;;
 EIC_independent_communist;Indian Socialist Patriotic Front;;;;;;;;;;;;x
 EIC_independent_fascist;United Imperial Alliance;;;;;;;;;;;;x
 EVT9990001OPTA;Excellent.;;;;;;;;;;;;x,,,,,,,,,,,


### PR DESCRIPTION
There were many UTF-8 encoded files still, this change converts them to
the cp1252 encoding that the game expects. For a couple files this only
changes some comments, but this also fixes some actual text bugs.

`HFM/localisation/0000_minimod.csv` is of note because it contained
UTF-8 mojibake that was not valid cp1252. Since the invalid key came
from base game files it was easy to restore it to the original
characters.

---

When reviewing this PR, make sure you are looking at the changes with the correct encoding. For instance if using the Github web interface, your browser is likely to pick UTF-8 or fallback to auto-detection (with unpredictable results).

An example of a text bug that this PR fixes:

![utf8](https://user-images.githubusercontent.com/49937701/70111937-1bf00480-1654-11ea-8d78-0d1467def06d.png)

which was caused by:

https://github.com/SighPie/HFM/blob/38ca75c40063e08cbf696140e0ea68d76e6ace9d/HFM/decisions/FlavourMod_Africa.txt#L1710-L1712