### PR TITLE
Stop the religious effects in China more carefully

### DIFF
--- a/HFM/events/China.txt
+++ b/HFM/events/China.txt
@@ -27,12 +27,36 @@ country_event = {
 			limit = { owner = { has_country_flag = activate_experimental_railroad } NOT = { experimental_railroad = 1 } }
 			owner = { activate_technology = experimental_railroad  clr_country_flag = activate_experimental_railroad }
 		}
-		remove_country_modifier = missionary_activity
-		religion = mahayana
-		set_country_flag = mahayana_country
-		clr_country_flag = protestant_country
-		clr_country_flag = change_to_protestant
-		clr_country_flag = missionary_activity
+		
+		# end the religious effects of losing the 2nd Opium War
+		random_owned = {
+			limit = {
+				owner = {
+					has_country_flag = gave_up_2nd_opium
+				}
+			}
+			
+			owner = {
+				remove_country_modifier = missionary_activity
+				clr_country_flag = change_to_protestant
+				clr_country_flag = missionary_activity
+				
+				random_owned = {
+					limit = {
+						owner = {
+							NOT = { tag = TPG }
+						}
+					}
+					
+					owner = {
+						religion = mahayana
+						set_country_flag = mahayana_country
+						clr_country_flag = protestant_country
+					}
+				}
+			}
+		}
+		
 		MCK = { all_core = { add_core = CHI } }
 		XBI = { all_core = { add_core = CHI } }
 		XIN = { all_core = { add_core = CHI } }


### PR DESCRIPTION
When Qing loses the 2nd Opium War it may be forced to sign the Treaty of
Tientsin which historically allowed foreign missionary activity in China
among other things. To translate this into in-game mechanics, `QNG` is
temporarily switched to a protestant country. This is then undone upon
Westernisation, switching back to Mahayana. (There also are accompanying
country flags and modifiers.)

This has the unfortunate side-effect that Taiping also switches to
Mahayana upon Westernisation no matter what. With this change the
Westernisation of Chinese countries is more careful and preserves the
state religion of the Heavenly Kingdom.

---

Fixes #139. This PR has been tested.