### PR TITLE
Occupation of the congo requirements

### DIFF
--- a/HFM/decisions/FlavourMod_Africa.txt
+++ b/HFM/decisions/FlavourMod_Africa.txt
@@ -663,6 +663,7 @@ political_decisions = {
 					1980 = { empty = yes } #Congo
 				}
 				AND = {
+					invention = the_dark_continent
 					owns = 1981
 					1966 = { empty = yes } #Ubangi-Shari
 				}	

--- a/HFM/decisions/FlavourMod_Africa.txt
+++ b/HFM/decisions/FlavourMod_Africa.txt
@@ -622,7 +622,6 @@ political_decisions = {
 			has_global_flag = berlin_conference
 			NOT = { has_global_flag = congo_failed }
 			is_greater_power = yes
-			exists = yes
 			OR = {
 				AND = {
 					owns = 1972
@@ -654,11 +653,11 @@ political_decisions = {
 					1976 = { empty = yes } #Gabon
 				}
 				AND = {
-					OR = { 
+					OR = {
 						has_global_flag = called_congo_conference
 						1962 = { empty = no }
 					}
-					owns = 1977 
+					owns = 1977
 					1976 = { empty = no } #Gabon
 					1980 = { empty = yes } #Congo
 				}
@@ -666,7 +665,7 @@ political_decisions = {
 					invention = the_dark_continent
 					owns = 1981
 					1966 = { empty = yes } #Ubangi-Shari
-				}	
+				}
 				AND = {
 					invention = the_dark_continent
 					owns = 1967
@@ -680,9 +679,8 @@ political_decisions = {
 			random_owned = {
 				limit = {
 					owner = {
-						owns = 1972 #Libreville
-						1974 = { empty = yes } #Gabon
-						invention = colonial_negotiations
+						owns = 1972
+						1976 = { empty = yes } #Gabon
 					}
 				}
 				1974 = { secede_province = THIS any_pop = { literacy = -0.99 } }
@@ -693,14 +691,13 @@ political_decisions = {
 			random_owned = {
 				limit = {
 					owner = {
-						owns = 1977	
-						1976 = { empty = no } #Gabon
-						1980 = { empty = yes } #Congo
-						invention = colonial_negotiations
-						OR = { 
+						OR = {
 							has_global_flag = called_congo_conference
 							1962 = { empty = no }
 						}
+						owns = 1977
+						1976 = { empty = no } #Gabon
+						1980 = { empty = yes } #Congo
 					}
 				}
 				1980 = { secede_province = THIS any_pop = { literacy = -0.99 } }
@@ -711,10 +708,9 @@ political_decisions = {
 			random_owned = {
 				limit = {
 					owner = {
-						owns = 1981	
-						1966 = { empty = yes } #Ubangi-Shari
-						1962 = { empty = no } #Cameroon
 						invention = the_dark_continent
+						owns = 1981
+						1966 = { empty = yes } #Ubangi-Shari
 					}
 				}
 				1965 = { secede_province = THIS any_pop = { literacy = -0.99 } life_rating = 5 }
@@ -730,9 +726,9 @@ political_decisions = {
 			random_owned = {
 				limit = {
 					owner = {
-						owns = 1967	
-						1819 = { empty = yes }
 						invention = the_dark_continent
+						owns = 1967
+						1819 = { empty = yes }
 					}
 				}
 				1818 = { secede_province = THIS any_pop = { literacy = -0.99 } life_rating = 5 }


### PR DESCRIPTION
> # Add missing requirement to Occupation of the Congo
> 
> Closes #158.
> 
> The mismatch between the decision requirements and the test performed in
> the actual effects resulted in decision spam.

> # Harmonise requirements & effects
> 
> A caretaker follow-up patch. This does not alter the semantics of the
> decision, but is designed to help future changes avoid a repeat of #158.
> 
> Opening a split view of the file to look at both the `allow` and
> `effect` blocks simultaneously can help understand this change, as the
> diff is somewhat noisy.

This PR has been tested.