### PR TITLE
Fix annex_korea edge cases

### DIFF
--- a/HFM/decisions/Japan.txt
+++ b/HFM/decisions/Japan.txt
@@ -646,14 +646,19 @@ political_decisions = {
 				tag = JAP
 				tag = TKG
 			}
-			has_country_modifier = fukoku_kyohei
-			is_greater_power = yes
-			NOT = { has_country_flag = annexed_korea }
 			exists = KOR
+			OR = {
+				has_country_modifier = fukoku_kyohei
+				any_owned_province = { is_core = KOR }
+			}
+			OR = {
+				NOT = { has_country_flag = annexed_korea }
+				ai = yes
+			}
 		}
 		
 		allow = {
-			NOT = { war_with = KOR	}
+			war = no
 			NOT = { truce_with = KOR }
 			OR = {
 				AND = {
@@ -686,47 +691,29 @@ political_decisions = {
 				leave_alliance = THIS
 				relation = { who = THIS value = -100 }
 			}
-			random_country = {
-				limit = {
-					tag = KOR
-					ai = yes
-					civilized = no
-				}
-				annex_to = THIS
-			}
 			
 			random_country = {
 				limit = {
 					tag = KOR
 					ai = yes
-					civilized = yes
 				}
 				civilized = no
 				annex_to = THIS
-			}
-			
-			random_country = {
-				limit = {
-					tag = KOR
-					exists = no
-				}
 				civilized = yes
 			}
 			
-			random_country = {
+			random_owned = {
 				limit = {
-					tag = KOR
-					ai = no
+					KOR = { ai = no }
 				}
-				casus_belli = {
-					target = THIS
-					type = become_independent
-					months = 12
-				}
-				war = {
-					target = THIS
-					attacker_goal = {
-						casus_belli = become_independent
+				
+				owner = {
+					release_vassal = KOR
+					leave_alliance = KOR
+					war = {
+						target = KOR
+						attacker_goal = { casus_belli = conquest_any }
+						defender_goal = { casus_belli = become_independent }
 					}
 				}
 			}


### PR DESCRIPTION
This change partly includes upstream HPM updates to the decision, though
it does try to preserve HFM specificities.

* Leave Korea Westernised after annexation

  Behind the scenes Korea undergoes de-Westernisation in order to
  incorporate its provinces as Japanese colonies. This fixes the use of
  a `random_country` scope (which cannot target a non-existing country)
  that prevented proper (re-)Westernisation.

  As a knock-on effect, this should make late game liberation crises
  that go to war over Korea actually function. Without this change, the
  Liberate Country CB would fizzle on the second day of the war.

* Properly set up the conquest war against player Korea