### PR TITLE
Normalise Boer War call to arms

### DIFF
--- a/HFM/events/BoerWar.txt
+++ b/HFM/events/BoerWar.txt
@@ -1908,42 +1908,95 @@ country_event = { #Oranje & Natalia can rally to Transvaal's side in Second Boer
 #      	    Friendly Great Powers Come to Boer Aid				#
 #																#
 #################################################################
-country_event = { #Rally to the Boer Cause?
-	id = 6060
-	title = "EVTNAME6060" 
-	desc = "EVTDESC6060"
-	picture = "boer_war"
 
-	is_triggered_only = yes
+country_event = {
+    id      = 6060
+    title   = "EVTNAME6060" # Rally to the Boer Cause?
+    desc    = "EVTDESC6060"
+    picture = "boer_war"
 
-	option = {
-		name = "EVT6060OPTA" #Defend the Boer Cause
-		relation = {
-			who = TRN
-			value = 400
-		}
-		diplomatic_influence = { 
-			who = TRN 
-			value = 200 
-		}
-		create_alliance = TRN
-		TRN = {
-           war = {               #No target initiates a one-day war that automatically resolves in a WP, but call_ally causes the new ally 
-               attacker_goal = {
-                   casus_belli = humiliate
-               }
-               call_ally = yes
-           }
-           badboy = -6       #Add this in so that you don't have to eat the infamy from declaring a war with no CB fabricated already.
-       }
-		ai_chance = { factor = 10}
-	}
+    is_triggered_only = yes
 
-	option = { #None of Our Concern
-		name = "EVT6060OPTB"
-		prestige = -5
-		ai_chance = { factor = 90 }
-	}
+    option = {
+        name = "EVT6060OPTA" # Defend the Boer Cause
+
+        TRN = {
+            # AI calls allies into war
+            random_owned = {
+                limit = { owner = { ai = yes } }
+
+                owner = {
+                    relation = {
+                        who = TRN
+                        value = 400
+                    }
+
+                    diplomatic_influence = {
+                        who = TRN
+                        value = 200
+                    }
+
+                    create_alliance = TRN
+
+                    war = {
+                        attacker_goal = {
+                            casus_belli = call_allies_cb
+                        }
+                        call_ally = yes
+                    }
+                }
+            }
+
+            # player is notified of new ally
+            random_owned = {
+                limit = { owner = { ai = no } }
+
+                owner = {
+                    country_event = 6061
+                }
+            }
+        }
+
+        ai_chance = { factor = 10 }
+    }
+
+    option = {
+        name = "EVT6060OPTB" # None of Our Concern
+
+        prestige = -5
+
+        ai_chance = { factor = 90 }
+    }
+}
+
+country_event = {
+    id      = 6061
+    title   = "EVT6061NAME" # Our New Ally
+    desc    = "EVT6061DESC"
+    picture = "boer_war"
+
+    is_triggered_only        = yes
+    allow_multiple_instances = yes
+
+    immediate = {
+        FROM = {
+            relation = {
+                who = THIS
+                value = 400
+            }
+
+            diplomatic_influence = {
+                who = THIS
+                value = 200
+            }
+
+            create_alliance = THIS
+        }
+    }
+
+    option = {
+        name = "EVT6061OPTA" # Fantastic news.
+    }
 }
 
 #################################################################

--- a/HFM/localisation/00_SAF_Misc.csv
+++ b/HFM/localisation/00_SAF_Misc.csv
@@ -212,6 +212,9 @@ EVTNAME6060;Support the Boers in their defense of their freedom?;;;;;;;;;;;;x,,,
 EVTDESC6060;The United Kingdom have decided, in their insatiable desire to dominate the African continent, to attempt to bring the free people of the sovereign South African Republic under their tyrannical heel.  We can stand by and watch this happen, or we can make a statement as a world leader to stand up against British imperial ambition here and now.;;;;;;;;;;;;x,,,,,,,,,,,,,,,,,,,,,,
 EVT6060OPTA;The Boer Republics have a right to self-determination, we will fight for that right!;;;;;;;;;;;;x,,,,,,,,,,,,,,,,,,,,,
 EVT6060OPTB;This isn't out fight.;;;;;;;;;;;;x,,,,,,,,,,,,,,,,,,,,,
+EVT6061NAME;Our New Ally;;;;;;;;;;;;;
+EVT6061DESC;Ever the beacon of liberty, $FROMCOUNTRY$ has valiantly risen to the occasion. They have promised to guarantee our liberty and independence, and to aid us in war. With $FROMCOUNTRY_ADJ$ gallantry by our side we finally have a chance against British imperialism!;;;;;;;;;;;;;
+EVT6061OPTA;Fantastic news.;;;;;;;;;;;;;
 griqua;Cape Coloured;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;x;;;;;;;;;;;;;;x;;;;;;;,,,,,,,,,,,,
 claim_namibia_title;Settle Namibia;;;;;;;;;;;;;;;;;;;;;;;x;;;;,,,,,,,,,,,,
 claim_namibia_desc;The sparsely inhabited lands of Namibia to our North-West have begun to attract the attention of the Great Powers, and we may soon find an aggressive colonial power moving in next door. It is critical for the maintenance of our national security that we take this area to prevent this. Of particular interest is the bay called Angra Pequena by the Portuguese, as a hanseatic merchant from Hamburg named Adolf Lüderitz has expressed interest in a partnership with our colonial company to settle the area.;;;;;;;;;;;;;;;;;;;;;;;x;;;;,,,,,,,,,,,,


### PR DESCRIPTION
- ensure Boer War call to arms is infamy neutral (it was deducting 3
  extra) and similar to e.g. `events/GreatWar_Events.txt` call to arms
- make it AI only
- for player country, notify of the new alliance instead

---

This change has been tested.

edit: I should mention that this introduces no new functionality. This is mostly for the convenience of not having a target-less war trip up error detectors through using the special call to arms CB.