### PR TITLE
Fix lack writing system

### DIFF
--- a/HFM/common/event_modifiers.txt
+++ b/HFM/common/event_modifiers.txt
@@ -327,7 +327,7 @@ negotiating_treaty = {
 }
 
 lacks_writing_system = {
-	education_efficiency_modifier = -1.0
+	education_efficiency_modifier = -0.5
 	icon = 6
 }
 


### PR DESCRIPTION
This modifier makes it impossible to westernize for uncivilized nations with no access to the sea and literacy below 3% (For example, Bambara Empire)